### PR TITLE
Update code that calculates the position of the mouse within the tile

### DIFF
--- a/LATIF/sample_app (1)/sample_app/js/map.js
+++ b/LATIF/sample_app (1)/sample_app/js/map.js
@@ -18,10 +18,6 @@ const dataLayer = L.tileLayer(tileURL, {
   ],
 }).addTo(map);
 
-// function timeout(t) {
-//   return new Promise(resolve => setTimeout(resolve, t));
-// }
-
 function isImageLoaded(img) {
   return new Promise((resolve, reject) => {
     if (img.complete) {
@@ -33,30 +29,11 @@ function isImageLoaded(img) {
   });
 }
 
-let anyvalues = new Set();
-map.on('mousemove', async function (e) {
-  // const value = e;
-  // Get the pixel value in the dataLayer at the mouse position
-
-  // Get the coordinates of the tile that was clicked.
-  // The following is adapted from https://stackoverflow.com/a/37018281/123776
-  const tileSize = { x: 256, y: 256 };
-  const pixelPoint = map.project(e.latlng, map.getZoom()).floor();
-  let coords = pixelPoint.unscaleBy(tileSize).floor();
-  coords.z = Math.floor(map.getZoom());
-
-  // Get the top-left pixel position of the tile.
-  const tileTopLeftPos = dataLayer._getTilePos(coords);
-
-  // Get the clicked pixel within the tile.
-  const clickAbsolutePos = e.containerPoint;
-  const clickOffsetPos = clickAbsolutePos.subtract(tileTopLeftPos);
-
-  // Get the pixel color in the tile.
-  const tileId = `${coords.x}:${coords.y}:${coords.z}`;
+async function getTileCanvas(dataLayer, tileId) {
   dataLayer._tileCanvases = dataLayer._tileCanvases || {};
   let tileCanvasInfo = dataLayer._tileCanvases[tileId];
   if (!tileCanvasInfo) {
+    console.log(`No tile canvas info found for ${tileId}.`);
     tileCanvasInfo = dataLayer._tileCanvases[tileId] = { lock: true };
 
     if (dataLayer._tooltip) {
@@ -67,6 +44,7 @@ map.on('mousemove', async function (e) {
     if (!dataLayer._tiles[tileId]) { return }
 
     const tileImg = dataLayer._tiles[tileId].el;
+    console.log(`Creating tile canvas for ${tileId}.`, tileImg);
     await isImageLoaded(tileImg);
     const tileCanvas = document.createElement('canvas');
     tileCanvas.width = 256;
@@ -83,17 +61,55 @@ map.on('mousemove', async function (e) {
   }
   else if (tileCanvasInfo.lock) {
     // There's already a request for this tile in progress.
+    throw 'Tile has already been requested, but is not yet ready.';
+  }
+  return tileCanvasInfo;
+}
+
+let anyvalues = new Set();
+
+map.on('mousemove', async function (e) {
+  // There are a few different types of positions that we might want to get:
+  // * The position of a point relative to the top-left corner of the map view (i.e., the "container point").
+  // * The position of a point relative to the top-left corner of the tile that was clicked. (i.e., the "tile point")
+  // * The position of a point relative to the top-left corner of the entire map (i.e., the "map point")
+
+  // Get the map point of the mouse cursor.
+  const mouseLatLng = e.latlng;
+  const mouseMapPoint = map.project(mouseLatLng);
+
+  // Get the x, y, and z coordinates of the tile that was clicked.
+  const tileSize = { x: 256, y: 256 };
+  const tileIdValues = mouseMapPoint.unscaleBy(tileSize).floor();
+  tileIdValues.z = Math.floor(map.getZoom());
+
+  // Get the map point of the top-left corner of the tile.
+  const tileMapPoint = tileIdValues.scaleBy(tileSize);
+
+  // Get the tile point of the mouse cursor (i.e., the pixel position relative
+  // to the top-left corner of the tile).
+  const mouseTilePoint = mouseMapPoint.subtract(tileMapPoint);
+
+  // Get the pixel color in the tile.
+  const tileId = `${tileIdValues.x}:${tileIdValues.y}:${tileIdValues.z}`;
+  let tileCanvasInfo = null;
+  try {
+    tileCanvasInfo = await getTileCanvas(dataLayer, tileId);
+  } catch (e) {
+    // The tile has already been requested, but is not yet ready.
     return;
   }
-
+  if (!tileCanvasInfo) {
+    // The tile is not present in the dataLayer.
+    return;
+  }
   const ctx = tileCanvasInfo.ctx;
 
-  const pixel = ctx.getImageData(clickOffsetPos.x, clickOffsetPos.y, 1, 1).data;
+  const pixel = ctx.getImageData(mouseTilePoint.x, mouseTilePoint.y, 1, 1).data;
   const color = `RGBA(${pixel[0]}, ${pixel[1]}, ${pixel[2]}, ${pixel[3]})`;
   const lctype = lctypes[color];
   if (!anyvalues.has(color)) {
     anyvalues.add(color);
-    console.log(color);
   }
 
   if (!dataLayer._tooltip) {
@@ -108,31 +124,8 @@ map.on('mousemove', async function (e) {
   dataLayer._tooltip.close();
   if(lctype) {
     dataLayer._tooltip
-        .setLatLng(e.latlng)
-        .setContent(`The land cover type is ${lctype}`)
-        .openOn(map);
+      .setLatLng(e.latlng)
+      .setContent(`The land cover type is ${lctype}`)
+      .openOn(map);
   }
-
-
-  // const pixel = dataLayer._getTilePos(e.latlng);
-  // const tile = dataLayer._getTileCoords(pixel);
-  // const clickOffsetPos = dataLayer._getTilePos(tile);
-  // const value = dataLayer._getTileData(tile);
-
-  // const lcTypes = {
-  //   0: 'Water',
-  //   1: 'Evergreen Needleleaf Forest',
-
-  // }
-
-  // Show a tooltip at the mouse position with the value of the pixel
-  // L.tooltip({
-  //   position: 'bottom',
-  //   noWrap: true,
-  //   offset: L.point(0, 0),
-  //   direction: 'top',
-  //   permanent: false
-  // })
-
-  // console.log(value);
 });


### PR DESCRIPTION
### How this works:

In order to get the color of a pixel at any given point, we have to know where that point is on a given tile. That's not easy. Getting the position of the mouse with respect to a tile involves three steps. Note in the following images, the blue rectangle is the browser window, the orange rectangle is the full map (which extends beyond the browser window), and the green rectangle is the tile the mouse is over.

First, find the position of the mouse with respect to the map origin. We call this the `mouseMapPoint`:

![image](https://github.com/xueningz22/final_project_509/assets/146749/650ce8f1-8979-40df-9132-99d60ad0e38f)

Second, find the position of the tile with respect to the map by taking the `mouseMapPoint` and rounding down to the nearest 256x256 pixels (which is the size of a given tile). We call this the `tileMapPoint`:

![image](https://github.com/xueningz22/final_project_509/assets/146749/bbd4e5e3-ed5f-4bd9-8e91-3de7a34d6e68)

Finally, find the position of the mouse with respect to the tile it's in by subtracting the `tileMapPoint` from the `mouseMapPoint`. We call this the `mouseTilePoint`:

![image](https://github.com/xueningz22/final_project_509/assets/146749/04071050-82cd-454a-8c17-00d1f43b0d68)

From there we can get the image data from the tile and extract the specific pixel at the `mouseTilePoint` using a function named `getImageData`.